### PR TITLE
✨ feat: 상품 목록 조회 기능

### DIFF
--- a/core/core-api/src/docs/asciidoc/product/index.adoc
+++ b/core/core-api/src/docs/asciidoc/product/index.adoc
@@ -31,20 +31,58 @@ include::{snippets}/상품 등록/http-response.adoc[]
 
 include::{snippets}/상품 등록/response-fields.adoc[]
 
-== 상품 상세 조회
+== 상품 조회
 
-=== Curl Request
+=== 상품 상세 조회
+
+==== Curl Request
 
 include::{snippets}/상품 상세 조회/curl-request.adoc[]
 
-=== Http Request
+==== Http Request
 
 include::{snippets}/상품 상세 조회/http-request.adoc[]
 
-=== Http Response
+==== Http Response
 
 include::{snippets}/상품 상세 조회/http-response.adoc[]
 
-=== Response Fields
+==== Response Fields
 
 include::{snippets}/상품 상세 조회/response-fields.adoc[]
+
+=== 상품 목록 조회 (빈 커서)
+
+==== Curl Request
+
+include::{snippets}/상품 목록 조회 (빈 커서)/curl-request.adoc[]
+
+==== Http Request
+
+include::{snippets}/상품 목록 조회 (빈 커서)/http-request.adoc[]
+
+==== Http Response
+
+include::{snippets}/상품 목록 조회 (빈 커서)/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/상품 목록 조회 (빈 커서)/response-fields.adoc[]
+
+=== 상품 목록 조회 (커서)
+
+==== Curl Request
+
+include::{snippets}/상품 목록 조회 (커서)/curl-request.adoc[]
+
+==== Http Request
+
+include::{snippets}/상품 목록 조회 (커서)/http-request.adoc[]
+
+==== Http Response
+
+include::{snippets}/상품 목록 조회 (커서)/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/상품 목록 조회 (커서)/response-fields.adoc[]

--- a/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/controller/v1/ProductController.java
+++ b/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/controller/v1/ProductController.java
@@ -4,12 +4,17 @@ import com.fstuckint.baedalyogieats.core.api.product.controller.v1.request.Produ
 import com.fstuckint.baedalyogieats.core.api.product.controller.v1.response.ProductResponse;
 import com.fstuckint.baedalyogieats.core.api.product.domain.ProductResult;
 import com.fstuckint.baedalyogieats.core.api.product.domain.ProductService;
+import com.fstuckint.baedalyogieats.core.api.product.support.Cursor;
 import com.fstuckint.baedalyogieats.core.api.product.support.response.ApiResponse;
+import com.fstuckint.baedalyogieats.core.api.product.support.response.SliceResult;
+import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,6 +38,18 @@ public class ProductController {
     public ApiResponse<ProductResponse> findProduct(@PathVariable String productUuid) {
         ProductResult result = productService.find(UUID.fromString(productUuid));
         return ApiResponse.success(ProductResponse.of(result));
+    }
+
+    @GetMapping("/api/v1/products")
+    public ApiResponse<SliceResult<List<ProductResponse>>> readProducts(@RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "10") long limit, @RequestParam(defaultValue = "id") String sortKey,
+            @RequestParam(defaultValue = "ASC") Sort.Direction sort) {
+
+        List<ProductResult> products = productService.read(new Cursor(cursor, limit, sortKey, sort));
+        ProductResult lastProduct = products.getLast();
+        String nextCursor = Cursor.createNextCursor(lastProduct.uuid(), lastProduct.createdAt(),
+                lastProduct.updatedAt(), sortKey);
+        return ApiResponse.success(SliceResult.of(ProductResponse.of(products), limit, nextCursor));
     }
 
 }

--- a/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/controller/v1/response/ProductResponse.java
+++ b/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/controller/v1/response/ProductResponse.java
@@ -1,12 +1,21 @@
 package com.fstuckint.baedalyogieats.core.api.product.controller.v1.response;
 
 import com.fstuckint.baedalyogieats.core.api.product.domain.ProductResult;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
-public record ProductResponse(UUID uuid, String name, String description, int unitPrice, UUID storeUuid) {
+public record ProductResponse(UUID uuid, String name, String description, int unitPrice, UUID storeUuid,
+        LocalDateTime createdAt, LocalDateTime updatedAt) {
 
     public static ProductResponse of(ProductResult productResult) {
         return new ProductResponse(productResult.uuid(), productResult.name(), productResult.description(),
-                productResult.unitPrice(), productResult.storeUuid());
+                productResult.unitPrice(), productResult.storeUuid(), productResult.createdAt(),
+                productResult.updatedAt());
     }
+
+    public static List<ProductResponse> of(List<ProductResult> productResults) {
+        return productResults.stream().map(ProductResponse::of).toList();
+    }
+
 }

--- a/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/domain/ProductReader.java
+++ b/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/domain/ProductReader.java
@@ -1,0 +1,25 @@
+package com.fstuckint.baedalyogieats.core.api.product.domain;
+
+import com.fstuckint.baedalyogieats.core.api.product.support.Cursor;
+import com.fstuckint.baedalyogieats.storage.db.core.product.ProductRepository;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductReader {
+
+    private final ProductRepository productRepository;
+
+    public ProductReader(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    public List<ProductResult> read(Cursor cursor) {
+        return productRepository
+            .findByCursor(cursor.getUuid(), cursor.getTimestamp(), cursor.limit() + 1, cursor.sortKey(), cursor.sort())
+            .stream()
+            .map(ProductResult::of)
+            .toList();
+    }
+
+}

--- a/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/domain/ProductResult.java
+++ b/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/domain/ProductResult.java
@@ -1,12 +1,15 @@
 package com.fstuckint.baedalyogieats.core.api.product.domain;
 
 import com.fstuckint.baedalyogieats.storage.db.core.product.ProductEntity;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
-public record ProductResult(UUID uuid, String name, String description, int unitPrice, UUID storeUuid) {
+public record ProductResult(UUID uuid, String name, String description, int unitPrice, UUID storeUuid,
+        LocalDateTime createdAt, LocalDateTime updatedAt) {
 
     public static ProductResult of(ProductEntity productEntity) {
         return new ProductResult(productEntity.getUuid(), productEntity.getName(), productEntity.getDescription(),
-                productEntity.getUnitPrice(), productEntity.getStoreUuid());
+                productEntity.getUnitPrice(), productEntity.getStoreUuid(), productEntity.getCreatedAt(),
+                productEntity.getUpdatedAt());
     }
 }

--- a/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/domain/ProductService.java
+++ b/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/domain/ProductService.java
@@ -1,5 +1,7 @@
 package com.fstuckint.baedalyogieats.core.api.product.domain;
 
+import com.fstuckint.baedalyogieats.core.api.product.support.Cursor;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 
@@ -10,9 +12,12 @@ public class ProductService {
 
     private final ProductFinder productFinder;
 
-    public ProductService(ProductRegister productRegister, ProductFinder productFinder) {
+    private final ProductReader productReader;
+
+    public ProductService(ProductRegister productRegister, ProductFinder productFinder, ProductReader productReader) {
         this.productRegister = productRegister;
         this.productFinder = productFinder;
+        this.productReader = productReader;
     }
 
     public ProductResult register(Product product) {
@@ -21,6 +26,10 @@ public class ProductService {
 
     public ProductResult find(UUID productUuid) {
         return productFinder.find(productUuid);
+    }
+
+    public List<ProductResult> read(Cursor cursor) {
+        return productReader.read(cursor);
     }
 
 }

--- a/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/support/Cursor.java
+++ b/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/support/Cursor.java
@@ -1,0 +1,26 @@
+package com.fstuckint.baedalyogieats.core.api.product.support;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.springframework.data.domain.Sort;
+
+public record Cursor(String cursor, long limit, String sortKey, Sort.Direction sort) {
+
+    public UUID getUuid() {
+        return cursor != null ? UUID.fromString(cursor.split("_")[0]) : null;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return cursor != null ? LocalDateTime.parse(cursor.split("_")[1]) : null;
+    }
+
+    public static String encodeCursor(UUID uuid, LocalDateTime timestamp) {
+        return uuid.toString() + "_" + timestamp.toString();
+    }
+
+    public static String createNextCursor(UUID uuid, LocalDateTime createdAt, LocalDateTime updatedAt, String sortKey) {
+        LocalDateTime nextTimestamp = "createdAt".equals(sortKey) ? createdAt : updatedAt;
+        return encodeCursor(uuid, nextTimestamp);
+    }
+
+}

--- a/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/support/response/SliceResult.java
+++ b/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/product/support/response/SliceResult.java
@@ -1,0 +1,41 @@
+package com.fstuckint.baedalyogieats.core.api.product.support.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class SliceResult<S> {
+
+    private final S result;
+
+    @JsonProperty
+    private final boolean hasNext;
+
+    private final String nextCursor;
+
+    private SliceResult(S result, boolean hasNext, String nextCursor) {
+        this.result = result;
+        this.hasNext = hasNext;
+        this.nextCursor = nextCursor;
+    }
+
+    public S getResult() {
+        return result;
+    }
+
+    public boolean hasNext() {
+        return hasNext;
+    }
+
+    public String getNextCursor() {
+        return nextCursor;
+    }
+
+    public static <S> SliceResult<List<S>> of(List<S> result, long limit, String nextCursor) {
+        boolean hasNext = result.size() > limit;
+        if (hasNext) {
+            return new SliceResult<>(result.subList(0, (int) limit - 1), true, nextCursor);
+        }
+        return new SliceResult<>(result, false, null);
+    }
+
+}

--- a/core/core-api/src/test/java/com/fstuckint/baedalyogieats/core/api/product/controller/v1/ProductControllerTest.java
+++ b/core/core-api/src/test/java/com/fstuckint/baedalyogieats/core/api/product/controller/v1/ProductControllerTest.java
@@ -2,12 +2,16 @@ package com.fstuckint.baedalyogieats.core.api.product.controller.v1;
 
 import static com.fstuckint.baedalyogieats.test.api.RestDocsUtils.requestPreprocessor;
 import static com.fstuckint.baedalyogieats.test.api.RestDocsUtils.responsePreprocessor;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,10 +19,15 @@ import com.fstuckint.baedalyogieats.core.api.product.controller.v1.request.Produ
 import com.fstuckint.baedalyogieats.core.api.product.domain.Product;
 import com.fstuckint.baedalyogieats.core.api.product.domain.ProductResult;
 import com.fstuckint.baedalyogieats.core.api.product.domain.ProductService;
+import com.fstuckint.baedalyogieats.core.api.product.support.Cursor;
 import com.fstuckint.baedalyogieats.test.api.RestDocsTest;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.payload.JsonFieldType;
 
@@ -49,7 +58,8 @@ class ProductControllerTest extends RestDocsTest {
         int unitPrice = 10_000;
 
         Product product = new Product(name, description, unitPrice, storeUuid);
-        ProductResult productResult = new ProductResult(productUuid, name, description, unitPrice, storeUuid);
+        ProductResult productResult = new ProductResult(productUuid, name, description, unitPrice, storeUuid,
+                LocalDateTime.now(), LocalDateTime.now());
         when(productService.register(product)).thenReturn(productResult);
 
         ProductRegisterRequest request = new ProductRegisterRequest(name, description, unitPrice, storeUuid.toString());
@@ -72,12 +82,15 @@ class ProductControllerTest extends RestDocsTest {
                             fieldWithPath("data.description").type(JsonFieldType.STRING).description("상품 설명"),
                             fieldWithPath("data.unitPrice").type(JsonFieldType.NUMBER).description("가격"),
                             fieldWithPath("data.storeUuid").type(JsonFieldType.STRING).description("가게 UUID"),
+                            fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("상품 생성 시간"),
+                            fieldWithPath("data.updatedAt").type(JsonFieldType.STRING).description("상품 수정 시간"),
                             fieldWithPath("error").type(JsonFieldType.NULL).ignored())));
     }
 
     @Test
     void 상품_상세_조회() {
-        ProductResult productResult = new ProductResult(productUuid, "상품", "상품 설명", 10_000, storeUuid);
+        ProductResult productResult = new ProductResult(productUuid, "상품", "상품 설명", 10_000, storeUuid,
+                LocalDateTime.now(), LocalDateTime.now());
         when(productService.find(productUuid)).thenReturn(productResult);
 
         given().contentType("application/json")
@@ -91,7 +104,91 @@ class ProductControllerTest extends RestDocsTest {
                             fieldWithPath("data.description").type(JsonFieldType.STRING).description("상품 설명"),
                             fieldWithPath("data.unitPrice").type(JsonFieldType.NUMBER).description("가격"),
                             fieldWithPath("data.storeUuid").type(JsonFieldType.STRING).description("가게 UUID"),
+                            fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("상품 생성 시간"),
+                            fieldWithPath("data.updatedAt").type(JsonFieldType.STRING).description("상품 수정 시간"),
                             fieldWithPath("error").type(JsonFieldType.NULL).ignored())));
+    }
+
+    @Test
+    void 빈_커서로_상품_목록_조회() {
+        UUID storeUuid = UUID.randomUUID();
+        List<ProductResult> productResults = List.of(
+                new ProductResult(UUID.randomUUID(), "상품1", "설명1", 10000, storeUuid, LocalDateTime.now(),
+                        LocalDateTime.now()),
+                new ProductResult(UUID.randomUUID(), "상품2", "설명2", 20000, storeUuid, LocalDateTime.now(),
+                        LocalDateTime.now()));
+
+        when(productService.read(any(Cursor.class))).thenReturn(productResults);
+
+        given().param("cursor", "")
+            .param("limit", 10)
+            .param("sortKey", "createdAt")
+            .param("sort", Sort.Direction.ASC.name())
+            .get("/api/v1/products")
+            .then()
+            .status(HttpStatus.OK)
+            .apply(document("상품 목록 조회 (빈 커서)", requestPreprocessor(), responsePreprocessor(),
+                    queryParameters(parameterWithName("cursor").description("커서 (첫 페이지: null)").optional(),
+                            parameterWithName("limit").description("페이지 크기").optional(),
+                            parameterWithName("sortKey").description("정렬 키").optional(),
+                            parameterWithName("sort").description("정렬 방향 (ASC / DESC)").optional()),
+                    responseFields(fieldWithPath("result").type(JsonFieldType.STRING).description("결과"),
+                            fieldWithPath("data.result").type(JsonFieldType.ARRAY).description("상품 목록"),
+                            fieldWithPath("data.result[].uuid").type(JsonFieldType.STRING).description("상품 UUID"),
+                            fieldWithPath("data.result[].name").type(JsonFieldType.STRING).description("상품명"),
+                            fieldWithPath("data.result[].description").type(JsonFieldType.STRING).description("상품 설명"),
+                            fieldWithPath("data.result[].unitPrice").type(JsonFieldType.NUMBER).description("가격"),
+                            fieldWithPath("data.result[].storeUuid").type(JsonFieldType.STRING).description("가게 UUID"),
+                            fieldWithPath("data.result[].createdAt").type(JsonFieldType.STRING).description("상품 생성 시간"),
+                            fieldWithPath("data.result[].updatedAt").type(JsonFieldType.STRING).description("상품 수정 시간"),
+                            fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+                            fieldWithPath("data.nextCursor").type(JsonFieldType.NULL)
+                                .ignored()
+                                .description("다음 페이지 커서"),
+                            fieldWithPath("error").type(JsonFieldType.NULL).ignored())));
+
+        verify(productService).read(any(Cursor.class));
+    }
+
+    @Test
+    void 커서로_상품_목록_조회() {
+        UUID storeUuid = UUID.randomUUID();
+        List<ProductResult> productResults = IntStream.rangeClosed(1, 11)
+            .mapToObj(i -> new ProductResult(UUID.randomUUID(), "상품" + i, "설명" + i, i * 10000, storeUuid,
+                    LocalDateTime.now().minusHours(i), LocalDateTime.now().minusHours(i)))
+            .toList();
+        UUID lastProductUuid = UUID.randomUUID();
+        LocalDateTime lastProductTimestamp = LocalDateTime.now().minusHours(12);
+        String cursor = lastProductUuid + "_" + lastProductTimestamp;
+
+        when(productService.read(any(Cursor.class))).thenReturn(productResults);
+
+        given().param("cursor", cursor)
+            .param("limit", 10)
+            .param("sortKey", "createdAt")
+            .param("sort", Sort.Direction.DESC.name())
+            .get("/api/v1/products")
+            .then()
+            .status(HttpStatus.OK)
+            .apply(document("상품 목록 조회 (커서)", requestPreprocessor(), responsePreprocessor(),
+                    queryParameters(parameterWithName("cursor").description("커서 (UUID_타임스탬프 형식)"),
+                            parameterWithName("limit").description("페이지 크기"),
+                            parameterWithName("sortKey").description("정렬 키"),
+                            parameterWithName("sort").description("정렬 방향 (ASC / DESC)")),
+                    responseFields(fieldWithPath("result").type(JsonFieldType.STRING).description("결과"),
+                            fieldWithPath("data.result").type(JsonFieldType.ARRAY).description("상품 목록"),
+                            fieldWithPath("data.result[].uuid").type(JsonFieldType.STRING).description("상품 UUID"),
+                            fieldWithPath("data.result[].name").type(JsonFieldType.STRING).description("상품명"),
+                            fieldWithPath("data.result[].description").type(JsonFieldType.STRING).description("상품 설명"),
+                            fieldWithPath("data.result[].unitPrice").type(JsonFieldType.NUMBER).description("가격"),
+                            fieldWithPath("data.result[].storeUuid").type(JsonFieldType.STRING).description("가게 UUID"),
+                            fieldWithPath("data.result[].createdAt").type(JsonFieldType.STRING).description("상품 생성 시간"),
+                            fieldWithPath("data.result[].updatedAt").type(JsonFieldType.STRING).description("상품 수정 시간"),
+                            fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+                            fieldWithPath("data.nextCursor").type(JsonFieldType.STRING).description("다음 페이지 커서"),
+                            fieldWithPath("error").type(JsonFieldType.NULL).ignored())));
+
+        verify(productService).read(any(Cursor.class));
     }
 
 }

--- a/core/core-api/src/test/java/com/fstuckint/baedalyogieats/core/api/product/domain/ProductReaderTest.java
+++ b/core/core-api/src/test/java/com/fstuckint/baedalyogieats/core/api/product/domain/ProductReaderTest.java
@@ -1,0 +1,105 @@
+package com.fstuckint.baedalyogieats.core.api.product.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fstuckint.baedalyogieats.core.api.product.support.Cursor;
+import com.fstuckint.baedalyogieats.storage.db.core.product.ProductEntity;
+import com.fstuckint.baedalyogieats.storage.db.core.product.ProductRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Sort;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ProductReaderTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    private ProductReader productReader;
+
+    private List<ProductEntity> products;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        productReader = new ProductReader(productRepository);
+
+        // 15개의 테스트용 상품 데이터 생성
+        products = IntStream.rangeClosed(1, 15)
+            .mapToObj(i -> new ProductEntity("상품" + i, "설명" + i, i * 1000, UUID.randomUUID()))
+            .toList();
+    }
+
+    @Test
+    void 커서가_없을_때_첫_페이지_상품_목록을_조회한다() {
+        // given
+        final long limit = 10;
+        final String sortKey = "createdAt";
+        final Sort.Direction sort = Sort.Direction.ASC;
+        Cursor cursor = new Cursor(null, limit, sortKey, sort);
+        when(productRepository.findByCursor(cursor.getUuid(), cursor.getTimestamp(), cursor.limit() + 1,
+                cursor.sortKey(), cursor.sort()))
+            .thenReturn(products.subList(0, (int) limit));
+
+        // when
+        List<ProductResult> results = productReader.read(cursor);
+
+        // then
+        assertThat(results).hasSize((int) limit);
+        assertThat(results.getFirst().name()).isEqualTo("상품1");
+        assertThat(results.getFirst().unitPrice()).isEqualTo(1000);
+        assertThat(results.getLast().name()).isEqualTo("상품10");
+        assertThat(results.getLast().unitPrice()).isEqualTo(10000);
+    }
+
+    @Test
+    void 커서가_있을_때_다음_페이지의_상품_목록을_조회한다() {
+        // given
+        final long limit = 10;
+        final String sortKey = "createdAt";
+        final Sort.Direction sort = Sort.Direction.ASC;
+        UUID lastUuid = UUID.randomUUID();
+        LocalDateTime lastTimestamp = LocalDateTime.now();
+        Cursor cursor = new Cursor(Cursor.encodeCursor(lastUuid, lastTimestamp), limit, sortKey, sort);
+        when(productRepository.findByCursor(lastUuid, lastTimestamp, limit + 1, sortKey, sort))
+            .thenReturn(products.subList(10, 15));
+
+        // when
+        List<ProductResult> results = productReader.read(cursor);
+
+        // then
+        assertThat(results).hasSize(5);
+        assertThat(results.get(0).name()).isEqualTo("상품11");
+        assertThat(results.get(0).unitPrice()).isEqualTo(11000);
+        assertThat(results.get(4).name()).isEqualTo("상품15");
+        assertThat(results.get(4).unitPrice()).isEqualTo(15000);
+    }
+
+    @Test
+    void 마지막_페이지_이후_상품_목록을_조회하면_빈_목록이_반환된다() {
+        // given
+        final long limit = 10;
+        final String sortKey = "createdAt";
+        final Sort.Direction sort = Sort.Direction.ASC;
+        UUID lastUuid = UUID.randomUUID();
+        LocalDateTime lastTimestamp = LocalDateTime.now();
+        Cursor cursor = new Cursor(Cursor.encodeCursor(lastUuid, lastTimestamp), limit, sortKey, sort);
+        when(productRepository.findByCursor(lastUuid, lastTimestamp, limit + 1, sortKey, sort)).thenReturn(List.of());
+
+        // when
+        List<ProductResult> results = productReader.read(cursor);
+
+        // then
+        assertThat(results).isEmpty();
+    }
+
+}

--- a/core/core-api/src/test/java/com/fstuckint/baedalyogieats/core/api/product/domain/ProductServiceTest.java
+++ b/core/core-api/src/test/java/com/fstuckint/baedalyogieats/core/api/product/domain/ProductServiceTest.java
@@ -1,9 +1,12 @@
 package com.fstuckint.baedalyogieats.core.api.product.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fstuckint.baedalyogieats.core.api.product.support.Cursor;
 import com.fstuckint.baedalyogieats.storage.db.core.product.ProductEntity;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -11,6 +14,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -26,6 +30,9 @@ class ProductServiceTest {
     @Mock
     private ProductFinder productFinder;
 
+    @Mock
+    private ProductReader productReader;
+
     private ProductService productService;
 
     @BeforeEach
@@ -34,7 +41,7 @@ class ProductServiceTest {
         this.storeUuid = UUID.randomUUID();
 
         MockitoAnnotations.openMocks(this);
-        productService = new ProductService(productRegister, productFinder);
+        productService = new ProductService(productRegister, productFinder, productReader);
     }
 
     @Test
@@ -81,6 +88,23 @@ class ProductServiceTest {
         assertThat(result.description()).isEqualTo(description);
         assertThat(result.unitPrice()).isEqualTo(unitPrice);
         assertThat(result.storeUuid()).isEqualTo(storeUuid);
+    }
+
+    @Test
+    void 상품_목록을_조회한다() {
+        // given
+        Cursor cursor = new Cursor(null, 10, "createdAt", Sort.Direction.ASC);
+        List<ProductResult> expectedResults = List.of(
+                new ProductResult(UUID.randomUUID(), "상품1", "설명1", 1000, UUID.randomUUID(), null, null),
+                new ProductResult(UUID.randomUUID(), "상품2", "설명2", 2000, UUID.randomUUID(), null, null));
+        when(productReader.read(cursor)).thenReturn(expectedResults);
+
+        // when
+        List<ProductResult> results = productService.read(cursor);
+
+        // then
+        assertThat(results).isEqualTo(expectedResults);
+        verify(productReader).read(cursor);
     }
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,16 @@
 ### Application version ###
 applicationVersion=0.0.1-SNAPSHOT
-
 ### Project configs ###
 projectGroup=com.fstuckint.baedalyogieats
 javaVersion=21
-
 ### Plugin depdency versions ###
 asciidoctorConvertVersion=3.3.2
 springJavaFormatVersion=0.0.41
-
 ### Spring dependency versions ###
 springBootVersion=3.3.0
 springDependencyManagementVersion=1.1.5
 springCloudDependenciesVersion=2023.0.1
-
 ### External dependency versions ###
 sentryVersion=7.9.0
+### Database-related dependency versions ###
+querydslVersion=5.0.0

--- a/storage/db-core/build.gradle
+++ b/storage/db-core/build.gradle
@@ -4,6 +4,14 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'com.h2database:h2'
 
+    // Querydsl
+    implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // 추가
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 }

--- a/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/product/ProductRepository.java
+++ b/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/product/ProductRepository.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProductRepository extends JpaRepository<ProductEntity, UUID> {
+public interface ProductRepository extends JpaRepository<ProductEntity, UUID>, ProductRepositoryCustom {
 
     default ProductEntity add(ProductEntity productEntity) {
         return save(productEntity);

--- a/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/product/ProductRepositoryCustom.java
+++ b/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/product/ProductRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.fstuckint.baedalyogieats.storage.db.core.product;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Sort;
+
+public interface ProductRepositoryCustom {
+
+    List<ProductEntity> findByCursor(UUID lastUuid, LocalDateTime lastTimestamp, long limit, String sortKey,
+            Sort.Direction sort);
+
+}

--- a/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/product/ProductRepositoryImpl.java
+++ b/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/product/ProductRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.fstuckint.baedalyogieats.storage.db.core.product;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Sort;
+
+public class ProductRepositoryImpl implements ProductRepositoryCustom {
+
+    public static final String CREATED_AT = "createdAt";
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public ProductRepositoryImpl(EntityManager entityManager) {
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public List<ProductEntity> findByCursor(UUID lastUuid, LocalDateTime lastTimestamp, long limit, String sortKey,
+            Sort.Direction sort) {
+        QProductEntity qProductEntity = QProductEntity.productEntity;
+
+        BooleanExpression cursorCondition = createCursorCondition(qProductEntity, lastUuid, lastTimestamp, sortKey,
+                sort);
+        OrderSpecifier<?> orderSpecifier = createOrderSpecifier(qProductEntity, sortKey, sort);
+
+        return jpaQueryFactory.selectFrom(qProductEntity)
+            .where(cursorCondition)
+            .orderBy(orderSpecifier, qProductEntity.uuid.asc())
+            .limit(limit)
+            .fetch();
+    }
+
+    private BooleanExpression createCursorCondition(QProductEntity qProductEntity, UUID lastUuid,
+            LocalDateTime lastTimestamp, String sortKey, Sort.Direction sort) {
+        if (lastUuid == null || lastTimestamp == null) {
+            return qProductEntity.uuid.isNotNull();
+        }
+
+        DateTimePath<LocalDateTime> timeField = getTimeFiled(qProductEntity, sortKey);
+
+        if (sort == Sort.Direction.ASC) {
+            return timeField.after(lastTimestamp).or(timeField.eq(lastTimestamp).and(qProductEntity.uuid.gt(lastUuid)));
+        }
+        return timeField.before(lastTimestamp).or(timeField.eq(lastTimestamp).and(qProductEntity.uuid.lt(lastUuid)));
+    }
+
+    private OrderSpecifier<?> createOrderSpecifier(QProductEntity qProductEntity, String sortKey, Sort.Direction sort) {
+
+        DateTimePath<LocalDateTime> timeField = getTimeFiled(qProductEntity, sortKey);
+
+        Order order = sort == Sort.Direction.ASC ? Order.ASC : Order.DESC;
+        return new OrderSpecifier<>(order, timeField);
+    }
+
+    private DateTimePath<LocalDateTime> getTimeFiled(QProductEntity qProductEntity, String sortKey) {
+        return CREATED_AT.equals(sortKey) ? qProductEntity.createdAt : qProductEntity.updatedAt;
+    }
+
+}

--- a/storage/db-core/src/test/java/com/fstuckint/baedalyogieats/storage/db/core/product/ProductRepositoryIT.java
+++ b/storage/db-core/src/test/java/com/fstuckint/baedalyogieats/storage/db/core/product/ProductRepositoryIT.java
@@ -1,17 +1,22 @@
 package com.fstuckint.baedalyogieats.storage.db.core.product;
 
-import com.fstuckint.baedalyogieats.storage.db.CoreDbContextTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fstuckint.baedalyogieats.storage.db.CoreDbContextTest;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
 
 class ProductRepositoryIT extends CoreDbContextTest {
 
     private final ProductRepository productRepository;
 
     private UUID storeUuid;
+
+    private List<ProductEntity> products;
 
     public ProductRepositoryIT(ProductRepository productRepository) {
         this.productRepository = productRepository;
@@ -20,6 +25,16 @@ class ProductRepositoryIT extends CoreDbContextTest {
     @BeforeEach
     void setUp() {
         this.storeUuid = UUID.randomUUID();
+
+        productRepository.deleteAll();
+
+        products = new ArrayList<>();
+        for (int i = 0; i < 15; i++) {
+            ProductEntity product = new ProductEntity("상품 " + (i + 1), "상품 설명 " + (i + 1), 1000 * (i + 1),
+                    UUID.randomUUID());
+            products.add(product);
+        }
+        productRepository.saveAll(products);
     }
 
     @Test
@@ -38,6 +53,57 @@ class ProductRepositoryIT extends CoreDbContextTest {
         assertThat(addedProduct.getDescription()).isEqualTo("상품 설명");
         assertThat(addedProduct.getUnitPrice()).isEqualTo(1000);
         assertThat(addedProduct.getStoreUuid()).isEqualTo(storeUuid);
+    }
+
+    @Test
+    void 상품_UUID와_타임스탬프_기반_커서로_상품_목록의_첫_번째_페이지를_조회한다() {
+        // given
+        final long limit = 10;
+        String sortKey = "createdAt";
+        Sort.Direction sort = Sort.Direction.ASC;
+
+        // when
+        List<ProductEntity> firstPage = productRepository.findByCursor(null, null, limit, sortKey, sort);
+
+        // then
+        assertThat(firstPage).hasSize(10);
+        assertThat(firstPage.getFirst().getUuid()).isEqualTo(products.getFirst().getUuid());
+        assertThat(firstPage.getLast().getUuid()).isEqualTo(products.get(9).getUuid());
+    }
+
+    @Test
+    void 상품_UUID와_타임스탬프_기반_커서로_상품_목록의_두_번째_페이지를_조회한다() {
+        // given
+        final long limit = 10;
+        String sortKey = "createdAt";
+        Sort.Direction sort = Sort.Direction.ASC;
+
+        // when
+        List<ProductEntity> firstPage = productRepository.findByCursor(null, null, limit, sortKey, sort);
+        ProductEntity lastProduct = firstPage.getLast();
+        List<ProductEntity> secondPage = productRepository.findByCursor(lastProduct.getUuid(),
+                lastProduct.getCreatedAt(), limit, sortKey, sort);
+
+        // then
+        assertThat(secondPage).hasSize(5);
+        assertThat(secondPage.getFirst().getUuid()).isEqualTo(products.get(10).getUuid());
+        assertThat(secondPage.getLast().getUuid()).isEqualTo(products.getLast().getUuid());
+    }
+
+    @Test
+    void 상품_UUID와_타임스탬프_기반_커서로_마지막_상품_이후_조회_시_빈_리스트가_반환되어야_한다() {
+        // given
+        final long limit = 10;
+        String sortKey = "createdAt";
+        Sort.Direction sort = Sort.Direction.ASC;
+        ProductEntity lastProduct = products.getLast();
+
+        // when
+        List<ProductEntity> result = productRepository.findByCursor(lastProduct.getUuid(), lastProduct.getCreatedAt(),
+                limit, sortKey, sort);
+
+        // then
+        assertThat(result).isEmpty();
     }
 
 }


### PR DESCRIPTION
## 📌 PR 요약

<!-- 이 PR의 목적과 주요 변경 사항을 간단히 설명해주세요 -->
- [상품 목록 조회 API](https://nbcamp-ch3.gitbook.io/t-f/api-docs/undefined-4#undefined-2) 구현

## 🔍 주요 변경 사항

<!-- bullet point로 주요 변경 사항을 나열해주세요 -->
- 상품 목록 조회 API 추가
- 커서 기반 페이지네이션 구현
  - `UUID_Timestamp`를 커서로 사용
  - ex)`b0536dad-9831-4a58-8d58-b281a46f95db_2024-08-29T01:47:39.934266`


## 🧪 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트할 수 있는지 간단히 설명해주세요 -->
```bash
./gradlew restDocsTest
```

```bash
./gradlew test
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요? (필요한 경우)
  - `src/docs/asciidoc/product/index.adoc` 
  - [API 문서](https://nbcamp-ch3.gitbook.io/t-f/api-docs/undefined-4#undefined-2) 업데이트 예정

## 👀 리뷰어 체크 포인트

<!-- 리뷰어가 특별히 확인해야 할 부분이 있다면 언급해주세요 -->
- `storage:db-core` 모듈에 Querydsl 의존성을 추가했습니다.
- 상품 조회, 목록 조회 API 응답 필드에 생성일, 수정일 필드가 추가됐습니다.
- 커서 페이지네이션 시 다음 페이지가 존재하면 현재 페이지의 마지막 엔티티 UUID와 타임스탬프(생성일 or 수정일)로 다음 커서를 생성해 클라이언트에 다음 페이지 존재 여부와 함께 다음 커서를 제공합니다.
  - ex) `"hasNext": true`
  - ex) `"nextCursor": "b0536dad-9831-4a58-8d58-b281a46f95db_2024-08-29T01:47:39.934266"`
- `UUID`, `createdAt`, `updatedAt` 복합 인덱스로 쿼리 성능 최적화 해 볼 수 있을 것 같습니다. (테스트 필요)

## 🔗 관련 이슈

<!-- 관련 이슈가 있다면 여기에 링크해주세요. 예: Closes #123, Related to #456 -->

## 💬 기타 코멘트

<!-- 추가로 공유할 내용이 있다면 여기에 적어주세요 -->
