### PR TITLE
✨ feat: 가게 목록 조회 기능

### DIFF
--- a/core/core-api/src/docs/asciidoc/store/index.adoc
+++ b/core/core-api/src/docs/asciidoc/store/index.adoc
@@ -50,3 +50,39 @@ include::{snippets}/가게 상세 조회/http-response.adoc[]
 ==== Response Fields
 
 include::{snippets}/가게 상세 조회/response-fields.adoc[]
+
+=== 가게 목록 조회 (빈 커서)
+
+==== Curl Request
+
+include::{snippets}/가게 목록 조회 (빈 커서)/curl-request.adoc[]
+
+==== Http Request
+
+include::{snippets}/가게 목록 조회 (빈 커서)/http-request.adoc[]
+
+==== Http Response
+
+include::{snippets}/가게 목록 조회 (빈 커서)/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/가게 목록 조회 (빈 커서)/response-fields.adoc[]
+
+=== 가게 목록 조회 (커서)
+
+==== Curl Request
+
+include::{snippets}/가게 목록 조회 (커서)/curl-request.adoc[]
+
+==== Http Request
+
+include::{snippets}/가게 목록 조회 (커서)/http-request.adoc[]
+
+==== Http Response
+
+include::{snippets}/가게 목록 조회 (커서)/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/가게 목록 조회 (커서)/response-fields.adoc[]

--- a/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/store/controller/v1/response/StoreResponse.java
+++ b/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/store/controller/v1/response/StoreResponse.java
@@ -2,6 +2,7 @@ package com.fstuckint.baedalyogieats.core.api.store.controller.v1.response;
 
 import com.fstuckint.baedalyogieats.core.api.store.domain.StoreResult;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record StoreResponse(UUID uuid, String name, String description, String fullAddress, UUID categoryUuid,
@@ -11,5 +12,9 @@ public record StoreResponse(UUID uuid, String name, String description, String f
         return new StoreResponse(storeResult.uuid(), storeResult.name(), storeResult.description(),
                 storeResult.fullAddress(), storeResult.categoryUuid(), storeResult.categoryName(),
                 storeResult.ownerUuid(), storeResult.createdAt(), storeResult.updatedAt());
+    }
+
+    public static List<StoreResponse> of(List<StoreResult> storeResults) {
+        return storeResults.stream().map(StoreResponse::of).toList();
     }
 }

--- a/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/store/domain/StoreReader.java
+++ b/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/store/domain/StoreReader.java
@@ -1,0 +1,25 @@
+package com.fstuckint.baedalyogieats.core.api.store.domain;
+
+import com.fstuckint.baedalyogieats.core.api.store.support.Cursor;
+import com.fstuckint.baedalyogieats.storage.db.core.store.StoreRepository;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StoreReader {
+
+    private final StoreRepository storeRepository;
+
+    public StoreReader(StoreRepository storeRepository) {
+        this.storeRepository = storeRepository;
+    }
+
+    public List<StoreResult> read(Cursor cursor) {
+        return storeRepository
+            .findByCursor(cursor.getUuid(), cursor.getTimestamp(), cursor.limit() + 1, cursor.sortKey(), cursor.sort())
+            .stream()
+            .map(StoreResult::of)
+            .toList();
+    }
+
+}

--- a/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/store/domain/StoreService.java
+++ b/core/core-api/src/main/java/com/fstuckint/baedalyogieats/core/api/store/domain/StoreService.java
@@ -1,5 +1,7 @@
 package com.fstuckint.baedalyogieats.core.api.store.domain;
 
+import com.fstuckint.baedalyogieats.core.api.store.support.Cursor;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 
@@ -10,9 +12,12 @@ public class StoreService {
 
     private final StoreFinder storeFinder;
 
-    public StoreService(StoreRegister storeRegister, StoreFinder storeFinder) {
+    private final StoreReader storeReader;
+
+    public StoreService(StoreRegister storeRegister, StoreFinder storeFinder, StoreReader storeReader) {
         this.storeRegister = storeRegister;
         this.storeFinder = storeFinder;
+        this.storeReader = storeReader;
     }
 
     public StoreResult register(OwnerStore ownerStore) {
@@ -21,6 +26,10 @@ public class StoreService {
 
     public StoreResult find(UUID storeUuid) {
         return storeFinder.find(storeUuid);
+    }
+
+    public List<StoreResult> read(Cursor cursor) {
+        return storeReader.read(cursor);
     }
 
 }

--- a/core/core-api/src/test/java/com/fstuckint/baedalyogieats/core/api/store/controller/v1/StoreControllerTest.java
+++ b/core/core-api/src/test/java/com/fstuckint/baedalyogieats/core/api/store/controller/v1/StoreControllerTest.java
@@ -4,11 +4,14 @@ import static com.fstuckint.baedalyogieats.test.api.RestDocsUtils.requestPreproc
 import static com.fstuckint.baedalyogieats.test.api.RestDocsUtils.responsePreprocessor;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,11 +19,15 @@ import com.fstuckint.baedalyogieats.core.api.store.controller.v1.request.StoreRe
 import com.fstuckint.baedalyogieats.core.api.store.domain.OwnerStore;
 import com.fstuckint.baedalyogieats.core.api.store.domain.StoreResult;
 import com.fstuckint.baedalyogieats.core.api.store.domain.StoreService;
+import com.fstuckint.baedalyogieats.core.api.store.support.Cursor;
 import com.fstuckint.baedalyogieats.test.api.RestDocsTest;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.payload.JsonFieldType;
 
@@ -115,6 +122,92 @@ class StoreControllerTest extends RestDocsTest {
                             fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("가게 생성 시간"),
                             fieldWithPath("data.updatedAt").type(JsonFieldType.STRING).description("가게 수정 시간"),
                             fieldWithPath("error").type(JsonFieldType.NULL).ignored())));
+    }
+
+    @Test
+    void 빈_커서로_가게_목록_조회() {
+        List<StoreResult> storeResults = List.of(
+                new StoreResult(UUID.randomUUID(), "가게1", "가게 설명", "주소", UUID.randomUUID(), "한식", UUID.randomUUID(),
+                        LocalDateTime.now(), LocalDateTime.now()),
+                new StoreResult(UUID.randomUUID(), "가게2", "가게 설명", "주소", UUID.randomUUID(), "중식", UUID.randomUUID(),
+                        LocalDateTime.now(), LocalDateTime.now()));
+
+        when(storeService.read(any(Cursor.class))).thenReturn(storeResults);
+
+        given().param("cursor", "")
+            .param("limit", 10)
+            .param("sortKey", "createdAt")
+            .param("sort", Sort.Direction.ASC.name())
+            .get("/api/v1/stores")
+            .then()
+            .status(HttpStatus.OK)
+            .apply(document("가게 목록 조회 (빈 커서)", requestPreprocessor(), responsePreprocessor(),
+                    queryParameters(parameterWithName("cursor").description("커서 (첫 페이지: null)").optional(),
+                            parameterWithName("limit").description("페이지 크기").optional(),
+                            parameterWithName("sortKey").description("정렬 키").optional(),
+                            parameterWithName("sort").description("정렬 방향 (ASC / DESC)").optional()),
+                    responseFields(fieldWithPath("result").type(JsonFieldType.STRING).description("결과"),
+                            fieldWithPath("data.result").type(JsonFieldType.ARRAY).description("가게 목록"),
+                            fieldWithPath("data.result[].uuid").type(JsonFieldType.STRING).description("가게 UUID"),
+                            fieldWithPath("data.result[].name").type(JsonFieldType.STRING).description("상호명"),
+                            fieldWithPath("data.result[].description").type(JsonFieldType.STRING).description("가게 설명"),
+                            fieldWithPath("data.result[].fullAddress").type(JsonFieldType.STRING).description("주소"),
+                            fieldWithPath("data.result[].categoryUuid").type(JsonFieldType.STRING)
+                                .description("카테고리 UUID"),
+                            fieldWithPath("data.result[].categoryName").type(JsonFieldType.STRING).description("카테고리명"),
+                            fieldWithPath("data.result[].ownerUuid").type(JsonFieldType.STRING).description("사장님 UUID"),
+                            fieldWithPath("data.result[].createdAt").type(JsonFieldType.STRING).description("가게 생성 시간"),
+                            fieldWithPath("data.result[].updatedAt").type(JsonFieldType.STRING).description("가게 수정 시간"),
+                            fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+                            fieldWithPath("data.nextCursor").type(JsonFieldType.NULL)
+                                .ignored()
+                                .description("다음 페이지 커서"),
+                            fieldWithPath("error").type(JsonFieldType.NULL).ignored())));
+
+        verify(storeService).read(any(Cursor.class));
+    }
+
+    @Test
+    void 커서로_가게_목록_조회() {
+        List<StoreResult> storeResults = IntStream.rangeClosed(1, 11)
+            .mapToObj(i -> new StoreResult(UUID.randomUUID(), "가게" + i, "가게 설명", "주소", UUID.randomUUID(), "한식",
+                    UUID.randomUUID(), LocalDateTime.now().minusHours(i), LocalDateTime.now().minusHours(i)))
+            .toList();
+        UUID lastStoreUuid = UUID.randomUUID();
+        LocalDateTime lastStoreTimestamp = LocalDateTime.now().minusHours(12);
+        String cursor = lastStoreUuid + "_" + lastStoreTimestamp;
+
+        when(storeService.read(any(Cursor.class))).thenReturn(storeResults);
+
+        given().param("cursor", cursor)
+            .param("limit", 10)
+            .param("sortKey", "createdAt")
+            .param("sort", Sort.Direction.DESC.name())
+            .get("/api/v1/stores")
+            .then()
+            .status(HttpStatus.OK)
+            .apply(document("가게 목록 조회 (커서)", requestPreprocessor(), responsePreprocessor(),
+                    queryParameters(parameterWithName("cursor").description("커서 (UUID_타임스탬프 형식)"),
+                            parameterWithName("limit").description("페이지 크기"),
+                            parameterWithName("sortKey").description("정렬 키"),
+                            parameterWithName("sort").description("정렬 방향 (ASC / DESC)")),
+                    responseFields(fieldWithPath("result").type(JsonFieldType.STRING).description("결과"),
+                            fieldWithPath("data.result").type(JsonFieldType.ARRAY).description("가게 목록"),
+                            fieldWithPath("data.result[].uuid").type(JsonFieldType.STRING).description("가게 UUID"),
+                            fieldWithPath("data.result[].name").type(JsonFieldType.STRING).description("상호명"),
+                            fieldWithPath("data.result[].description").type(JsonFieldType.STRING).description("가게 설명"),
+                            fieldWithPath("data.result[].fullAddress").type(JsonFieldType.STRING).description("주소"),
+                            fieldWithPath("data.result[].categoryUuid").type(JsonFieldType.STRING)
+                                .description("카테고리 UUID"),
+                            fieldWithPath("data.result[].categoryName").type(JsonFieldType.STRING).description("카테고리명"),
+                            fieldWithPath("data.result[].ownerUuid").type(JsonFieldType.STRING).description("사장님 UUID"),
+                            fieldWithPath("data.result[].createdAt").type(JsonFieldType.STRING).description("가게 생성 시간"),
+                            fieldWithPath("data.result[].updatedAt").type(JsonFieldType.STRING).description("가게 수정 시간"),
+                            fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+                            fieldWithPath("data.nextCursor").type(JsonFieldType.STRING).description("다음 페이지 커서"),
+                            fieldWithPath("error").type(JsonFieldType.NULL).ignored())));
+
+        verify(storeService).read(any(Cursor.class));
     }
 
 }

--- a/core/core-api/src/test/java/com/fstuckint/baedalyogieats/core/api/store/domain/StoreReaderTest.java
+++ b/core/core-api/src/test/java/com/fstuckint/baedalyogieats/core/api/store/domain/StoreReaderTest.java
@@ -1,0 +1,117 @@
+package com.fstuckint.baedalyogieats.core.api.store.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fstuckint.baedalyogieats.core.api.store.support.Cursor;
+import com.fstuckint.baedalyogieats.storage.db.core.store.CategoryEntity;
+import com.fstuckint.baedalyogieats.storage.db.core.store.StoreEntity;
+import com.fstuckint.baedalyogieats.storage.db.core.store.StoreRepository;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@Transactional
+class StoreReaderTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    private StoreReader storeReader;
+
+    private List<StoreEntity> stores;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        storeReader = new StoreReader(storeRepository);
+
+        CategoryEntity category = new CategoryEntity("한식");
+        entityManager.persist(category);
+
+        stores = IntStream.rangeClosed(1, 15)
+            .mapToObj(i -> new StoreEntity("가게" + i, "가게 설명", "주소", UUID.randomUUID(), category))
+            .peek(entityManager::persist)
+            .toList();
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    void 커서가_없을_때_첫_페이지_가게_목록을_조회한다() {
+        // given
+        final long limit = 10;
+        final String sortKey = "createdAt";
+        final Sort.Direction sort = Sort.Direction.ASC;
+        Cursor cursor = new Cursor(null, limit, sortKey, sort);
+        when(storeRepository.findByCursor(cursor.getUuid(), cursor.getTimestamp(), cursor.limit() + 1, cursor.sortKey(),
+                cursor.sort()))
+            .thenReturn(stores.subList(0, (int) limit));
+
+        // when
+        List<StoreResult> results = storeReader.read(cursor);
+
+        // then
+        assertThat(results).hasSize((int) limit);
+        assertThat(results.getFirst().name()).isEqualTo("가게1");
+        assertThat(results.getLast().name()).isEqualTo("가게10");
+    }
+
+    @Test
+    void 커서가_있을_때_다음_페이지의_가게_목록을_조회한다() {
+        // given
+        final long limit = 10;
+        final String sortKey = "createdAt";
+        final Sort.Direction sort = Sort.Direction.ASC;
+        UUID lastUuid = UUID.randomUUID();
+        LocalDateTime lastTimestamp = LocalDateTime.now();
+        Cursor cursor = new Cursor(Cursor.encodeCursor(lastUuid, lastTimestamp), limit, sortKey, sort);
+        when(storeRepository.findByCursor(lastUuid, lastTimestamp, limit + 1, sortKey, sort))
+            .thenReturn(stores.subList(10, 15));
+
+        // when
+        List<StoreResult> results = storeReader.read(cursor);
+
+        // then
+        assertThat(results).hasSize(5);
+        assertThat(results.get(0).name()).isEqualTo("가게11");
+        assertThat(results.get(4).name()).isEqualTo("가게15");
+    }
+
+    @Test
+    void 마지막_페이지_이후_가게_목록을_조회하면_빈_목록이_반환된다() {
+        // given
+        final long limit = 10;
+        final String sortKey = "createdAt";
+        final Sort.Direction sort = Sort.Direction.ASC;
+        UUID lastUuid = UUID.randomUUID();
+        LocalDateTime lastTimestamp = LocalDateTime.now();
+        Cursor cursor = new Cursor(Cursor.encodeCursor(lastUuid, lastTimestamp), limit, sortKey, sort);
+        when(storeRepository.findByCursor(lastUuid, lastTimestamp, limit + 1, sortKey, sort)).thenReturn(List.of());
+
+        // when
+        List<StoreResult> results = storeReader.read(cursor);
+
+        // then
+        assertThat(results).isEmpty();
+    }
+
+}

--- a/core/core-api/src/test/java/com/fstuckint/baedalyogieats/core/api/store/domain/StoreServiceTest.java
+++ b/core/core-api/src/test/java/com/fstuckint/baedalyogieats/core/api/store/domain/StoreServiceTest.java
@@ -1,10 +1,14 @@
 package com.fstuckint.baedalyogieats.core.api.store.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fstuckint.baedalyogieats.core.api.store.support.Cursor;
 import com.fstuckint.baedalyogieats.storage.db.core.store.CategoryEntity;
 import com.fstuckint.baedalyogieats.storage.db.core.store.StoreEntity;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -12,6 +16,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -29,6 +34,9 @@ class StoreServiceTest {
     @Mock
     private StoreFinder storeFinder;
 
+    @Mock
+    private StoreReader storeReader;
+
     private StoreService storeService;
 
     @BeforeEach
@@ -38,7 +46,7 @@ class StoreServiceTest {
         this.storeUuid = UUID.randomUUID();
 
         MockitoAnnotations.openMocks(this);
-        storeService = new StoreService(storeRegister, storeFinder);
+        storeService = new StoreService(storeRegister, storeFinder, storeReader);
     }
 
     @Test
@@ -103,6 +111,25 @@ class StoreServiceTest {
         assertThat(result.fullAddress()).isEqualTo(fullAddress);
         assertThat(result.categoryUuid()).isEqualTo(categoryUuid);
         assertThat(result.categoryName()).isEqualTo(categoryName);
+    }
+
+    @Test
+    void 가게_목록을_조회한다() {
+        // given
+        Cursor cursor = new Cursor(null, 10, "createdAt", Sort.Direction.ASC);
+        List<StoreResult> expectedResults = List.of(
+                new StoreResult(UUID.randomUUID(), "가게1", "가게 설명", "주소", UUID.randomUUID(), "한식", UUID.randomUUID(),
+                        LocalDateTime.now(), LocalDateTime.now()),
+                new StoreResult(UUID.randomUUID(), "가게2", "가게 설명", "주소", UUID.randomUUID(), "한식", UUID.randomUUID(),
+                        LocalDateTime.now(), LocalDateTime.now()));
+        when(storeReader.read(cursor)).thenReturn(expectedResults);
+
+        // when
+        List<StoreResult> results = storeService.read(cursor);
+
+        // then
+        assertThat(results).isEqualTo(expectedResults);
+        verify(storeReader).read(cursor);
     }
 
 }

--- a/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/store/StoreRepository.java
+++ b/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/store/StoreRepository.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StoreRepository extends JpaRepository<StoreEntity, UUID> {
+public interface StoreRepository extends JpaRepository<StoreEntity, UUID>, StoreRepositoryCustom {
 
     default StoreEntity add(StoreEntity storeEntity) {
         return save(storeEntity);

--- a/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/store/StoreRepositoryCustom.java
+++ b/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/store/StoreRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.fstuckint.baedalyogieats.storage.db.core.store;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Sort;
+
+public interface StoreRepositoryCustom {
+
+    List<StoreEntity> findByCursor(UUID lastUuid, LocalDateTime lastTimestamp, long limit, String sortKey,
+            Sort.Direction sort);
+
+}

--- a/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/store/StoreRepositoryImpl.java
+++ b/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/store/StoreRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.fstuckint.baedalyogieats.storage.db.core.store;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Sort;
+
+public class StoreRepositoryImpl implements StoreRepositoryCustom {
+
+    public static final String CREATED_AT = "createdAt";
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public StoreRepositoryImpl(EntityManager entityManager) {
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public List<StoreEntity> findByCursor(UUID lastUuid, LocalDateTime lastTimestamp, long limit, String sortKey,
+            Sort.Direction sort) {
+        QStoreEntity qStoreEntity = QStoreEntity.storeEntity;
+
+        BooleanExpression cursorCondition = createCursorCondition(qStoreEntity, lastUuid, lastTimestamp, sortKey, sort);
+        OrderSpecifier<?> orderSpecifier = createOrderSpecifier(qStoreEntity, sortKey, sort);
+
+        return jpaQueryFactory.selectFrom(qStoreEntity)
+            .where(cursorCondition)
+            .orderBy(orderSpecifier, qStoreEntity.uuid.asc())
+            .limit(limit)
+            .fetch();
+    }
+
+    private BooleanExpression createCursorCondition(QStoreEntity qStoreEntity, UUID lastUuid,
+            LocalDateTime lastTimestamp, String sortKey, Sort.Direction sort) {
+        if (lastUuid == null || lastTimestamp == null) {
+            return qStoreEntity.uuid.isNotNull();
+        }
+
+        DateTimePath<LocalDateTime> timeField = getTimeFiled(qStoreEntity, sortKey);
+
+        if (sort == Sort.Direction.ASC) {
+            return timeField.after(lastTimestamp).or(timeField.eq(lastTimestamp).and(qStoreEntity.uuid.gt(lastUuid)));
+        }
+        return timeField.before(lastTimestamp).or(timeField.eq(lastTimestamp).and(qStoreEntity.uuid.lt(lastUuid)));
+    }
+
+    private OrderSpecifier<?> createOrderSpecifier(QStoreEntity qStoreEntity, String sortKey, Sort.Direction sort) {
+
+        DateTimePath<LocalDateTime> timeField = getTimeFiled(qStoreEntity, sortKey);
+
+        Order order = sort == Sort.Direction.ASC ? Order.ASC : Order.DESC;
+        return new OrderSpecifier<>(order, timeField);
+    }
+
+    private DateTimePath<LocalDateTime> getTimeFiled(QStoreEntity qStoreEntity, String sortKey) {
+        return CREATED_AT.equals(sortKey) ? qStoreEntity.createdAt : qStoreEntity.updatedAt;
+    }
+
+}

--- a/storage/db-core/src/test/java/com/fstuckint/baedalyogieats/storage/db/core/store/StoreRepositoryIT.java
+++ b/storage/db-core/src/test/java/com/fstuckint/baedalyogieats/storage/db/core/store/StoreRepositoryIT.java
@@ -4,22 +4,43 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fstuckint.baedalyogieats.storage.db.CoreDbContextTest;
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class StoreRepositoryIT extends CoreDbContextTest {
 
     private final StoreRepository storeRepository;
 
     private final EntityManager entityManager;
 
+    private List<StoreEntity> stores;
+
     public StoreRepositoryIT(StoreRepository storeRepository, EntityManager entityManager) {
         this.storeRepository = storeRepository;
         this.entityManager = entityManager;
     }
 
-    @Transactional
+    @BeforeEach
+    void setUp() {
+        CategoryEntity category = new CategoryEntity("한식");
+        entityManager.persist(category);
+
+        stores = IntStream.rangeClosed(1, 15)
+            .mapToObj(i -> new StoreEntity("가게" + i, "가게 설명", "주소", UUID.randomUUID(), category))
+            .peek(entityManager::persist)
+            .toList();
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
     @Test
     void 가게가_추가된_후_가게_UUID로_조회돼야_한다() {
         // given
@@ -44,6 +65,57 @@ class StoreRepositoryIT extends CoreDbContextTest {
         assertThat(addedStore.getUserUuid()).isEqualTo(userUuid);
         assertThat(addedStore.getCategoryEntity()).isNotNull();
         assertThat(addedStore.getCategoryEntity().getName()).isEqualTo("한식");
+    }
+
+    @Test
+    void 가게_UUID와_타임스탬프_기반_커서로_가게_목록의_첫_번째_페이지를_조회한다() {
+        // given
+        final long limit = 10;
+        String sortKey = "createdAt";
+        Sort.Direction sort = Direction.ASC;
+
+        // when
+        List<StoreEntity> firstPage = storeRepository.findByCursor(null, null, limit, sortKey, sort);
+
+        // then
+        assertThat(firstPage).hasSize(10);
+        assertThat(firstPage.getFirst().getUuid()).isEqualTo(stores.getFirst().getUuid());
+        assertThat(firstPage.getLast().getUuid()).isEqualTo(stores.get(9).getUuid());
+    }
+
+    @Test
+    void 가게_UUID와_타임스탬프_기반_커서로_가게_목록의_두_번째_페이지를_조회한다() {
+        // given
+        final long limit = 10;
+        String sortKey = "createdAt";
+        Sort.Direction sort = Direction.ASC;
+
+        // when
+        List<StoreEntity> firstPage = storeRepository.findByCursor(null, null, limit, sortKey, sort);
+        StoreEntity lastStore = firstPage.getLast();
+        List<StoreEntity> secondPage = storeRepository.findByCursor(lastStore.getUuid(), lastStore.getCreatedAt(),
+                limit, sortKey, sort);
+
+        // then
+        assertThat(secondPage).hasSize(5);
+        assertThat(secondPage.getFirst().getUuid()).isEqualTo(stores.get(10).getUuid());
+        assertThat(secondPage.getLast().getUuid()).isEqualTo(stores.getLast().getUuid());
+    }
+
+    @Test
+    void 가게_UUID와_타임스탬프_기반_커서로_마지막_가게_이후_조회_시_빈_리스트가_반환되어야_한다() {
+        // given
+        final long limit = 10;
+        String sortKey = "createdAt";
+        Sort.Direction sort = Sort.Direction.ASC;
+        StoreEntity lastStore = stores.getLast();
+
+        // when
+        List<StoreEntity> result = storeRepository.findByCursor(lastStore.getUuid(), lastStore.getCreatedAt(), limit,
+                sortKey, sort);
+
+        // then
+        assertThat(result).isEmpty();
     }
 
 }


### PR DESCRIPTION
## 📌 PR 요약

<!-- 이 PR의 목적과 주요 변경 사항을 간단히 설명해주세요 -->
- [가게 목록 조회 API](https://nbcamp-ch3.gitbook.io/t-f/api-docs/undefined-2#undefined-2) 구현

## 🔍 주요 변경 사항

<!-- bullet point로 주요 변경 사항을 나열해주세요 -->
- 가게 목록 조회 API 추가
- 커서 기반 페이지네이션 구현
  - `UUID_Timestamp`를 커서로 사용
  - ex) `e0982c04-163e-4f30-a7be-cba4b00d2fd0_2024-09-01T14:17:36.816034`

## 🧪 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트할 수 있는지 간단히 설명해주세요 -->
```bash
./gradlew test
```

```bash
./gradlew restDocsTest
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요? (필요한 경우)
  - `src/docs/asciidoc/store/index.adoc`

## 👀 리뷰어 체크 포인트

<!-- 리뷰어가 특별히 확인해야 할 부분이 있다면 언급해주세요 -->
- 커서 페이지네이션 시 다음 페이지가 존재하면 현재 페이지의 마지막 엔티티 UUID와 타임스탬프(생성일 or 수정일)로 다음 커서를 생성해 클라이언트에 다음 페이지 존재 여부와 함께 다음 커서를 제공합니다.
  - ex) `"hasNext": true`
  - ex) `"nextCursor": "e0982c04-163e-4f30-a7be-cba4b00d2fd0_2024-09-01T14:17:36.816034"`

## 🔗 관련 이슈

<!-- 관련 이슈가 있다면 여기에 링크해주세요. 예: Closes #123, Related to #456 -->

## 💬 기타 코멘트

<!-- 추가로 공유할 내용이 있다면 여기에 적어주세요 -->