### PR TITLE
🚑 fix: 베이스 엔티티 UUID 컬럼 타입 변경

### DIFF
--- a/storage/db-core/build.gradle
+++ b/storage/db-core/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation project(':core:core-enum')
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
     implementation 'com.h2database:h2'
 
     // Querydsl

--- a/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/BaseEntity.java
+++ b/storage/db-core/src/main/java/com/fstuckint/baedalyogieats/storage/db/core/BaseEntity.java
@@ -5,16 +5,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
-
+import java.time.LocalDateTime;
 import java.util.UUID;
-
 import lombok.Getter;
 import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
-import org.hibernate.type.SqlTypes;
 
 @MappedSuperclass
 @Getter
@@ -22,8 +17,6 @@ public abstract class BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @JdbcTypeCode(SqlTypes.BINARY)
-    @Column(columnDefinition = "BINARY(16)")
     private UUID uuid;
 
     @CreationTimestamp

--- a/storage/db-core/src/main/resources/db-core.yml
+++ b/storage/db-core/src/main/resources/db-core.yml
@@ -45,7 +45,7 @@ spring:
 storage:
   datasource:
     core:
-      driver-class-name: com.mysql.cj.jdbc.Driver
+      driver-class-name: org.postgresql.Driver
       jdbc-url: jdbc:mysql://${storage.database.core-db.url}
       username: ${storage.database.core-db.username}
       password: ${storage.database.core-db.password}
@@ -74,7 +74,7 @@ spring.config.activate.on-profile: dev
 storage:
   datasource:
     core:
-      driver-class-name: com.mysql.cj.jdbc.Driver
+      driver-class-name: org.postgresql.Driver
       jdbc-url: jdbc:mysql://${storage.database.core-db.url}
       username: ${storage.database.core-db.username}
       password: ${storage.database.core-db.password}
@@ -103,7 +103,7 @@ spring.config.activate.on-profile: staging
 storage:
   datasource:
     core:
-      driver-class-name: com.mysql.cj.jdbc.Driver
+      driver-class-name: org.postgresql.Driver
       jdbc-url: jdbc:mysql://${storage.database.core-db.url}
       username: ${storage.database.core-db.username}
       password: ${storage.database.core-db.password}


### PR DESCRIPTION
## 📌 PR 요약

<!-- 이 PR의 목적과 주요 변경 사항을 간단히 설명해주세요 -->
- UUID 컬럼 타입 변경

## 🔍 주요 변경 사항

<!-- bullet point로 주요 변경 사항을 나열해주세요 -->
- `BaseEntity` UUID 컬럼 타입 변경
  - `Binary(16)` -> `UUID`

## 🧪 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트할 수 있는지 간단히 설명해주세요 -->
```bash
./gradlew test
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트

<!-- 리뷰어가 특별히 확인해야 할 부분이 있다면 언급해주세요 -->
- PostgreSQL 통합 테스트 중 PostgreSQL은 `BaseEntity`의 `UUID` 컬럼 타입인`Binary(16)`을 지원하지 않아 기존 binary에서 uuid를 그대로 저장하도록 수정
- 로컬 H2 설정에서 PostgreSQL과 호환돼도록 설정했는데, 다시 살펴봐야 할 것 같습니다.

## 🔗 관련 이슈

<!-- 관련 이슈가 있다면 여기에 링크해주세요. 예: Closes #123, Related to #456 -->

## 💬 기타 코멘트

<!-- 추가로 공유할 내용이 있다면 여기에 적어주세요 -->